### PR TITLE
[JC-3] Create "All Stats" section with Team Card list 

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Preview } from "@storybook/react";
 
 const preview: Preview = {
@@ -10,6 +11,13 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ margin: '3em' }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default preview;

--- a/components/atoms/CountTag/CountTag.stories.ts
+++ b/components/atoms/CountTag/CountTag.stories.ts
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from 'storybook'
+
+import CountTag from './CountTag'
+
+const meta = {
+    title: 'Atoms/CountTag',
+    component: CountTag,
+    tags: ['autodocs']
+} satisfies Meta<typeof CountTag>
+
+export default meta
+
+type Story = StoryObj<typeof CountTag>
+
+export const Primary: Story = {
+    args: {
+        number: 12
+    }
+}

--- a/components/atoms/CountTag/CountTag.tsx
+++ b/components/atoms/CountTag/CountTag.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import styled from 'styled-components'
+import THEME from 'styles/theme'
+
+const CountTagContainer = styled.div`
+    background-color: ${THEME.colors.primaryBlue};
+    color: white;
+    font-size: 10px;
+    border-radius: 12px;
+    padding: 4px 8px;
+`
+
+interface Props {
+    number: number
+}
+
+const CountTag = ({ number }: Props) => {
+    return (
+        <CountTagContainer>
+            <p>{number}x</p>
+        </CountTagContainer>
+    )
+}
+
+export default CountTag

--- a/components/atoms/CountTag/index.ts
+++ b/components/atoms/CountTag/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CountTag'

--- a/components/molecules/StatisticsSection.tsx
+++ b/components/molecules/StatisticsSection.tsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components'
 import TextBoxStat from './TextBoxStat'
-import CountTag from '@/atoms/CountTag'
+import AllStatsSection from '@/organisms/AllStatsSection'
 
 const StatisticsWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
     width: 90%;
 `
 
@@ -148,6 +151,13 @@ const CountriesSection = () => {
     )
 }
 
+const TEAM_STATS = [
+    { team:'Bor. Mönchengladbach', number: 12 },
+    { team:'Bayern Munich', number: 167 },
+    { team:'Tottenham Hotspur', number: 9 },
+    { team:'Deportivo La Coruna', number: 1 }
+]
+
 const StatisticsSection = () => (
         <StatisticsWrapper>
             <MainContent>
@@ -155,8 +165,8 @@ const StatisticsSection = () => (
                 <TextBoxStat number={24} title='Teams' />
                 <TextBoxStat number={17} title='Stadiums' />
                 <TextBoxStat number={12} title='Countries' />
-                <CountTag number={12} />
             </MainContent>
+            <AllStatsSection teamStats={TEAM_STATS} />
         </StatisticsWrapper>
     )
 

--- a/components/molecules/StatisticsSection.tsx
+++ b/components/molecules/StatisticsSection.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import TextBoxStat from './TextBoxStat'
+import CountTag from '@/atoms/CountTag'
 
 const StatisticsWrapper = styled.div`
     width: 90%;
@@ -154,6 +155,7 @@ const StatisticsSection = () => (
                 <TextBoxStat number={24} title='Teams' />
                 <TextBoxStat number={17} title='Stadiums' />
                 <TextBoxStat number={12} title='Countries' />
+                <CountTag number={12} />
             </MainContent>
         </StatisticsWrapper>
     )

--- a/components/molecules/TeamStatCard/TeamStatCard.tsx
+++ b/components/molecules/TeamStatCard/TeamStatCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import CountTag from '@/atoms/CountTag'
+
+const TeamStatCardContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 6px;
+    background-color: white;
+    width: max-content;
+    padding: 4px;
+    flex-shrink: 0;
+`
+
+const Text = styled.p`
+    font-size: 12px;
+    font-weight: bold;
+`
+
+export interface TeamStat {
+    number: number
+    team: string
+}
+
+const TeamStatCard = ({ number, team }: TeamStat) => {
+    return (
+        <TeamStatCardContainer>
+            <Text>{team}</Text>
+            <CountTag number={number} />
+        </TeamStatCardContainer>
+    )
+}
+
+export default TeamStatCard

--- a/components/molecules/TeamStatCard/index.ts
+++ b/components/molecules/TeamStatCard/index.ts
@@ -1,0 +1,1 @@
+export { default, type TeamStat } from './TeamStatCard'

--- a/components/organisms/AllStatsSection/AllStatsSection.tsx
+++ b/components/organisms/AllStatsSection/AllStatsSection.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import TeamStatSection from '../TeamStatSection'
+import { type TeamStat } from '@/molecules/TeamStatCard'
+import THEME from 'styles/theme'
+
+const AllStatsSectionWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+`
+
+const AllStatsSectionContainer = styled.div`
+    display: flex;
+    padding: 8px 0px;
+    border-top: 2px solid white;
+`
+
+const Text = styled.p`
+    text-align: end;
+    font-size: 16px;
+    font-weight: bold;
+    color: ${THEME.colors.primaryBlue};
+`
+
+interface Props {
+    teamStats: TeamStat[]
+}
+
+const AllStatsSection = ({ teamStats }: Props) => {
+    return (
+        <AllStatsSectionWrapper>
+            <Text>{'All Stats >'}</Text>
+            <AllStatsSectionContainer>
+                <TeamStatSection teamStats={teamStats} />
+            </AllStatsSectionContainer>
+        </AllStatsSectionWrapper>
+    )
+}
+
+export default AllStatsSection

--- a/components/organisms/AllStatsSection/index.ts
+++ b/components/organisms/AllStatsSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AllStatsSection'

--- a/components/organisms/TeamStatSection/TeamStatSection.tsx
+++ b/components/organisms/TeamStatSection/TeamStatSection.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import TeamStatCard, { TeamStat } from '@/molecules/TeamStatCard'
+
+const TeamStatSectionContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    overflow-y: scroll;
+
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    &::-webkit-scrollbar {
+        display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+`
+
+interface Props {
+    teamStats: TeamStat[]
+}
+
+const TeamStatSection = ({ teamStats }: Props) => {
+    return (
+        <TeamStatSectionContainer>
+            {teamStats.map(stat => (
+                <TeamStatCard team={stat.team} number={stat.number} />
+            ))}
+        </TeamStatSectionContainer>
+    )
+}
+
+export default TeamStatSection

--- a/components/organisms/TeamStatSection/index.ts
+++ b/components/organisms/TeamStatSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TeamStatSection'

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,14 @@
 import { AppProps } from 'next/app'
 import '../styles/index.css'
 
+import { ThemeProvider } from "styled-components"
+
+import THEME from 'styles/theme'
+
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <ThemeProvider theme={THEME}>
+      <Component {...pageProps} />
+    </ThemeProvider>
+  )
 }

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,9 @@
+const THEME = {
+    colors: {
+        primaryBlack: '#000000',
+        primaryGray: '#D9D9D9',
+        primaryBlue: '#0057FF'
+    }
+}
+
+export default THEME;


### PR DESCRIPTION
Add All Stats section with team stat cards in the Profile page.

Resolves #3 

![Screenshot 2024-02-03 at 12 01 14](https://github.com/CarlosRafael22/jogoclub/assets/5307335/d2b82c7a-132c-47d5-b1dd-e73449168455)
