### PR TITLE
[JC-8] Create Typography component with Figma initial variants

### DIFF
--- a/components/atoms/CountTag/CountTag.tsx
+++ b/components/atoms/CountTag/CountTag.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
 import THEME from 'styles/theme'
+import Typography from '../Typography'
 
 const CountTagContainer = styled.div`
     background-color: ${THEME.colors.primaryBlue};
-    color: white;
-    font-size: 10px;
     border-radius: 12px;
     padding: 4px 8px;
 `
@@ -17,7 +16,7 @@ interface Props {
 const CountTag = ({ number }: Props) => {
     return (
         <CountTagContainer>
-            <p>{number}x</p>
+            <Typography variant='body3-bold' color='white'>{number}x</Typography>
         </CountTagContainer>
     )
 }

--- a/components/atoms/Typography/Typography.stories.tsx
+++ b/components/atoms/Typography/Typography.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from 'storybook'
+import Typography from './Typography'
+
+const meta = {
+    title: 'Atoms/Typography',
+    component: Typography
+} satisfies Meta<typeof Typography>
+
+export default meta
+
+type Story = StoryObj<typeof Typography>
+
+export const Primary: Story = {
+    args: {
+        children: 'Typography example',
+        variant: 'body1-regular'
+    }
+}

--- a/components/atoms/Typography/Typography.tsx
+++ b/components/atoms/Typography/Typography.tsx
@@ -38,9 +38,13 @@ const propertiesMapping = {
     }
 }
 
-const Text = styled.p<Props>`
+const Text = styled.p.withConfig({
+    // To avoid "it looks like an unknown prop align is being sent through to the DOM"
+    // A prop that fails the test in shouldForwardProp isn't passed down
+    shouldForwardProp: (prop) => !["align", "variant"].includes(prop)
+  })<Props>`
   ${(props) => propertiesMapping[props.variant]}
-  ${(props) => `text-align: ${props.align};`}
+  text-align: ${props => props.align};
   ${(props) => props.color && `color: ${props.color};`}
 `;
 

--- a/components/atoms/Typography/Typography.tsx
+++ b/components/atoms/Typography/Typography.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-type TypographyVariant = 'body1-regular' | 'body1-bold' | 'body2-regular' | 'body2-bold' | 'body3-regular' | 'body3-bold'
+type TypographyVariant = 'body1-regular' | 'body1-bold' | 'body2-regular' | 'body2-bold' | 'body3-regular' | 'body3-bold' | 'subtitle2-regular' | 'subtitle2-bold'
 type TypographyAlign = 'left' | 'center' | 'right'
 
 interface Props {
@@ -34,6 +34,14 @@ const propertiesMapping = {
     },
     'body3-bold': {
         'font-size': '10px',
+        'font-weight': 'bold'
+    },
+    'subtitle2-regular': {
+        'font-size': '20px',
+        'font-weight': 'normal'
+    },
+    'subtitle2-bold': {
+        'font-size': '20px',
         'font-weight': 'bold'
     }
 }

--- a/components/atoms/Typography/Typography.tsx
+++ b/components/atoms/Typography/Typography.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { type ComponentPropsWithoutRef } from 'react'
 import styled from 'styled-components'
 
 type TypographyVariant = 'body1-regular' | 'body1-bold' | 'body2-regular' | 'body2-bold' | 'body3-regular' | 'body3-bold' | 'subtitle2-regular' | 'subtitle2-bold'
 type TypographyAlign = 'left' | 'center' | 'right'
 
-interface Props {
+interface Props extends ComponentPropsWithoutRef<"input"> {
     variant: TypographyVariant
     align?: TypographyAlign
     color?: string
@@ -56,8 +56,8 @@ const Text = styled.p.withConfig({
   ${(props) => props.color && `color: ${props.color};`}
 `;
 
-const Typography = ({ variant, align = 'center', color, children }: Props) => (
-    <Text variant={variant} align={align} color={color}>{children}</Text>
+const Typography = ({ variant, align = 'center', color, children, ...restOfProps }: Props) => (
+    <Text variant={variant} align={align} color={color} {...restOfProps}>{children}</Text>
 )
 
 export default Typography

--- a/components/atoms/Typography/Typography.tsx
+++ b/components/atoms/Typography/Typography.tsx
@@ -41,7 +41,7 @@ const propertiesMapping = {
 const Text = styled.p<Props>`
   ${(props) => propertiesMapping[props.variant]}
   ${(props) => `text-align: ${props.align};`}
-  ${(props) => `${props.color} && color: ${props.color};`}
+  ${(props) => props.color && `color: ${props.color};`}
 `;
 
 const Typography = ({ variant, align = 'center', color, children }: Props) => (

--- a/components/atoms/Typography/Typography.tsx
+++ b/components/atoms/Typography/Typography.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import styled from 'styled-components'
+
+type TypographyVariant = 'body1-regular' | 'body1-bold' | 'body2-regular' | 'body2-bold' | 'body3-regular' | 'body3-bold'
+type TypographyAlign = 'left' | 'center' | 'right'
+
+interface Props {
+    variant: TypographyVariant
+    align?: TypographyAlign
+    color?: string
+    children: React.ReactNode
+}
+
+const propertiesMapping = {
+    'body1-regular': {
+        'font-size': '16px',
+        'font-weight': 'normal'
+    },
+    'body1-bold': {
+        'font-size': '16px',
+        'font-weight': 'bold'
+    },
+    'body2-regular': {
+        'font-size': '12px',
+        'font-weight': 'normal'
+    },
+    'body2-bold': {
+        'font-size': '12px',
+        'font-weight': 'bold'
+    },
+    'body3-regular': {
+        'font-size': '10px',
+        'font-weight': 'normal'
+    },
+    'body3-bold': {
+        'font-size': '10px',
+        'font-weight': 'bold'
+    }
+}
+
+const Text = styled.p<Props>`
+  ${(props) => propertiesMapping[props.variant]}
+  ${(props) => `text-align: ${props.align};`}
+  ${(props) => `${props.color} && color: ${props.color};`}
+`;
+
+const Typography = ({ variant, align = 'center', color, children }: Props) => (
+    <Text variant={variant} align={align} color={color}>{children}</Text>
+)
+
+export default Typography

--- a/components/atoms/Typography/index.tsx
+++ b/components/atoms/Typography/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Typography'

--- a/components/molecules/ProfileHeader.tsx
+++ b/components/molecules/ProfileHeader.tsx
@@ -1,20 +1,12 @@
 import styled from "styled-components";
 import RoundedImage from "@/atoms/RoundedImage";
+import Typography from "@/atoms/Typography";
 
-const Name = styled.p`
-    font-weight: 700;
-    font-size: 20px;
+const Name = styled(Typography)`
     margin-top: 4px;
 `
 
-const Username = styled.p`
-    font-weight: 700;
-    font-size: 16px;
-`
-
-const Description = styled.p`
-    font-weight: 700;
-    font-size: 14px;
+const Description = styled(Typography)`
     margin-top: 4px;
 `
 
@@ -28,9 +20,9 @@ const ProfileHeader = () => {
     return (
         <ProfileHeaderWrapper>
             <RoundedImage src="/assets/profile_page/profile.png" alt="Avatar" />
-            <Name>Rafael Leitao</Name>
-            <Username>@maisumdiadejogo</Username>
-            <Description>Futebol pela Alemanha e Europa #groundhopping</Description>
+            <Name variant="subtitle2-bold">Rafael Leitao</Name>
+            <Typography variant="body1-bold">@maisumdiadejogo</Typography>
+            <Description variant="body2-bold">Futebol pela Alemanha e Europa #groundhopping</Description>
         </ProfileHeaderWrapper>
     )
 }

--- a/components/molecules/TeamStatCard/TeamStatCard.tsx
+++ b/components/molecules/TeamStatCard/TeamStatCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import Typography from '@/atoms/Typography'
 
 import CountTag from '@/atoms/CountTag'
 
@@ -14,11 +15,6 @@ const TeamStatCardContainer = styled.div`
     flex-shrink: 0;
 `
 
-const Text = styled.p`
-    font-size: 12px;
-    font-weight: bold;
-`
-
 export interface TeamStat {
     number: number
     team: string
@@ -27,7 +23,7 @@ export interface TeamStat {
 const TeamStatCard = ({ number, team }: TeamStat) => {
     return (
         <TeamStatCardContainer>
-            <Text>{team}</Text>
+            <Typography variant='body2-bold'>{team}</Typography>
             <CountTag number={number} />
         </TeamStatCardContainer>
     )

--- a/components/molecules/TextBoxStat/TextBoxStat.tsx
+++ b/components/molecules/TextBoxStat/TextBoxStat.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import Typography from '@/atoms/Typography'
 
 const TextBoxContainer = styled.div`
     display: flex;
@@ -17,8 +18,8 @@ interface Props {
 const TextBoxStat = ({ number, title }: Props) => {
     return (
         <TextBoxContainer>
-            <p style={{ fontSize: '20px', fontWeight: 'bold' }}>{number}</p>
-            <p style={{ fontSize: '12px' }}>{title}</p>
+            <Typography variant='subtitle2-bold'>{number}</Typography>
+            <Typography variant='body2-regular'>{title}</Typography>
         </TextBoxContainer>
     )
 }

--- a/components/organisms/AllStatsSection/AllStatsSection.tsx
+++ b/components/organisms/AllStatsSection/AllStatsSection.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import TeamStatSection from '../TeamStatSection'
 import { type TeamStat } from '@/molecules/TeamStatCard'
+import Typography from '@/atoms/Typography'
 import THEME from 'styles/theme'
 
 const AllStatsSectionWrapper = styled.div`
@@ -30,7 +31,7 @@ interface Props {
 const AllStatsSection = ({ teamStats }: Props) => {
     return (
         <AllStatsSectionWrapper>
-            <Text>{'All Stats >'}</Text>
+            <Typography variant='body1-bold' align='right' color={THEME.colors.primaryBlue}>{'All Stats >'}</Typography>
             <AllStatsSectionContainer>
                 <TeamStatSection teamStats={teamStats} />
             </AllStatsSectionContainer>

--- a/components/organisms/TeamStatSection/TeamStatSection.tsx
+++ b/components/organisms/TeamStatSection/TeamStatSection.tsx
@@ -27,7 +27,7 @@ const TeamStatSection = ({ teamStats }: Props) => {
     return (
         <TeamStatSectionContainer>
             {teamStats.map(stat => (
-                <TeamStatCard team={stat.team} number={stat.number} />
+                <TeamStatCard team={stat.team} number={stat.number} key={stat.team} />
             ))}
         </TeamStatSectionContainer>
     )


### PR DESCRIPTION
Adds Typography component with some initial variants.
Each variant has it's own `font-size` and `font-weight` configured based on the variant name.
Typography accepts normal `p` tag properties and have 3 props: `variant`, `align` and `color`.

In this PR, we also refactored some components to use `Typography` instead of `p` directly.

Example use:
```javascript
<Typography variant='body1-bold' align='right' color={THEME.colors.primaryBlue}>{'All Stats >'}</Typography>
```

resolves #8 