### PR TITLE
[JC-5] Add Stadiums cards to "All Stats" section

### DIFF
--- a/components/molecules/StadiumStatCard/StadiumStatCard.stories.tsx
+++ b/components/molecules/StadiumStatCard/StadiumStatCard.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from 'storybook'
+import StadiumStatCard from './StadiumStatCard'
+
+const meta = {
+    title: 'Molecules/StadiumStatCard',
+    component: StadiumStatCard
+} satisfies Meta<typeof StadiumStatCard>
+
+export default meta
+
+type Story = StoryObj<typeof StadiumStatCard>
+
+export const Primary: Story = {
+    args: {
+        stadium:'Estádio do Clube Desportivo das Aves',
+        location: 'Vila das Aves - Santo Tirso, Portugal',
+        number: 1
+    },
+}

--- a/components/molecules/StadiumStatCard/StadiumStatCard.tsx
+++ b/components/molecules/StadiumStatCard/StadiumStatCard.tsx
@@ -7,13 +7,13 @@ import CountTag from '@/atoms/CountTag'
 const StadiumStatCardContainer = styled.div`
     display: flex;
     align-items: flex-end;
-    gap: 16px;
+    gap: 8px;
     border-radius: 6px;
     background-color: white;
     width: max-content;
     padding: 8px;
     flex-shrink: 0;
-    height: 80px;
+    height: 90px;
 `
 
 const StadiumInfoContainer = styled.div`
@@ -28,6 +28,17 @@ const StadiumInfoContainer = styled.div`
 
 const StadiumName = styled(Typography)`
     line-height: 18px;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;  
+`
+
+const StadiumLocation = styled(Typography)`
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
 `
 
 export interface StadiumStat {
@@ -41,7 +52,7 @@ const StadiumStatCard = ({ number, stadium, location }: StadiumStat) => {
         <StadiumStatCardContainer>
             <StadiumInfoContainer>
                 <StadiumName variant='body1-bold' align='left'>{stadium}</StadiumName>
-                <Typography variant='body2-regular' align='left'>{location}</Typography>
+                <StadiumLocation variant='body2-regular' align='left'>{location}</StadiumLocation>
             </StadiumInfoContainer>
             <CountTag number={number} />
         </StadiumStatCardContainer>

--- a/components/molecules/StadiumStatCard/StadiumStatCard.tsx
+++ b/components/molecules/StadiumStatCard/StadiumStatCard.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import styled from 'styled-components'
+import Typography from '@/atoms/Typography'
+
+import CountTag from '@/atoms/CountTag'
+
+const StadiumStatCardContainer = styled.div`
+    display: flex;
+    align-items: flex-end;
+    gap: 16px;
+    border-radius: 6px;
+    background-color: white;
+    width: max-content;
+    padding: 8px;
+    flex-shrink: 0;
+    height: 80px;
+`
+
+const StadiumInfoContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+    align-items: flex-start; 
+    max-width: 140px;
+    height: 100%;
+    justify-content: space-between;
+`
+
+const StadiumName = styled(Typography)`
+    line-height: 18px;
+`
+
+export interface StadiumStat {
+    stadium: string
+    location: string
+    number: number
+}
+
+const StadiumStatCard = ({ number, stadium, location }: StadiumStat) => {
+    return (
+        <StadiumStatCardContainer>
+            <StadiumInfoContainer>
+                <StadiumName variant='body1-bold' align='left'>{stadium}</StadiumName>
+                <Typography variant='body2-regular' align='left'>{location}</Typography>
+            </StadiumInfoContainer>
+            <CountTag number={number} />
+        </StadiumStatCardContainer>
+    )
+}
+
+export default StadiumStatCard

--- a/components/molecules/StadiumStatCard/index.ts
+++ b/components/molecules/StadiumStatCard/index.ts
@@ -1,0 +1,1 @@
+export { default, type StadiumStat } from './StadiumStatCard'

--- a/components/molecules/StatisticsSection.tsx
+++ b/components/molecules/StatisticsSection.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import TextBoxStat from './TextBoxStat'
 import AllStatsSection from '@/organisms/AllStatsSection'
+import { TEAM_STATS, STADIUM_STATS } from 'const/data'
 
 const StatisticsWrapper = styled.div`
     display: flex;
@@ -151,13 +152,6 @@ const CountriesSection = () => {
     )
 }
 
-const TEAM_STATS = [
-    { team:'Bor. Mönchengladbach', number: 12 },
-    { team:'Bayern Munich', number: 167 },
-    { team:'Tottenham Hotspur', number: 9 },
-    { team:'Deportivo La Coruna', number: 1 }
-]
-
 const StatisticsSection = () => (
         <StatisticsWrapper>
             <MainContent>
@@ -166,7 +160,7 @@ const StatisticsSection = () => (
                 <TextBoxStat number={17} title='Stadiums' />
                 <TextBoxStat number={12} title='Countries' />
             </MainContent>
-            <AllStatsSection teamStats={TEAM_STATS} />
+            <AllStatsSection teamStats={TEAM_STATS} stadiumStats={STADIUM_STATS} />
         </StatisticsWrapper>
     )
 

--- a/components/molecules/TeamStatCard/TeamStatCard.tsx
+++ b/components/molecules/TeamStatCard/TeamStatCard.tsx
@@ -11,7 +11,7 @@ const TeamStatCardContainer = styled.div`
     border-radius: 6px;
     background-color: white;
     width: max-content;
-    padding: 4px;
+    padding: 4px 8px;
     flex-shrink: 0;
 `
 

--- a/components/organisms/AllStatsSection/AllStatsSection.tsx
+++ b/components/organisms/AllStatsSection/AllStatsSection.tsx
@@ -5,6 +5,8 @@ import TeamStatSection from '../TeamStatSection'
 import { type TeamStat } from '@/molecules/TeamStatCard'
 import Typography from '@/atoms/Typography'
 import THEME from 'styles/theme'
+import { StadiumStat } from '@/molecules/StadiumStatCard/StadiumStatCard'
+import StadiumStatSection from '../StadiumStatSection/StadiumStatSection'
 
 const AllStatsSectionWrapper = styled.div`
     display: flex;
@@ -13,27 +15,24 @@ const AllStatsSectionWrapper = styled.div`
 
 const AllStatsSectionContainer = styled.div`
     display: flex;
+    flex-direction: column;
+    gap: 8px;
     padding: 8px 0px;
     border-top: 2px solid white;
 `
 
-const Text = styled.p`
-    text-align: end;
-    font-size: 16px;
-    font-weight: bold;
-    color: ${THEME.colors.primaryBlue};
-`
-
 interface Props {
     teamStats: TeamStat[]
+    stadiumStats: StadiumStat[]
 }
 
-const AllStatsSection = ({ teamStats }: Props) => {
+const AllStatsSection = ({ teamStats, stadiumStats }: Props) => {
     return (
         <AllStatsSectionWrapper>
             <Typography variant='body1-bold' align='right' color={THEME.colors.primaryBlue}>{'All Stats >'}</Typography>
             <AllStatsSectionContainer>
                 <TeamStatSection teamStats={teamStats} />
+                <StadiumStatSection stadiumStats={stadiumStats} />
             </AllStatsSectionContainer>
         </AllStatsSectionWrapper>
     )

--- a/components/organisms/StadiumStatSection/StadiumStatSection.stories.tsx
+++ b/components/organisms/StadiumStatSection/StadiumStatSection.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from 'storybook'
+import StadiumStatSection from './StadiumStatSection'
+import { STADIUM_STATS } from 'const/data'
+
+const meta = {
+    title: 'Organisms/StadiumStatSection',
+    component: StadiumStatSection
+} satisfies Meta<typeof StadiumStatSection>
+
+export default meta
+
+type Story = StoryObj<typeof StadiumStatSection>
+
+export const Primary: Story = {
+    args: {
+        stadiumStats: STADIUM_STATS
+    },
+}

--- a/components/organisms/StadiumStatSection/StadiumStatSection.tsx
+++ b/components/organisms/StadiumStatSection/StadiumStatSection.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import StadiumStatCard, { StadiumStat } from '@/molecules/StadiumStatCard'
+
+const StadiumStatSectionContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    overflow-y: scroll;
+
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    &::-webkit-scrollbar {
+        display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+`
+
+interface Props {
+    stadiumStats: StadiumStat[]
+}
+
+const StadiumStatSection = ({ stadiumStats }: Props) => {
+    return (
+        <StadiumStatSectionContainer>
+            {stadiumStats.map(stat => (
+                <StadiumStatCard stadium={stat.stadium} location={stat.location} number={stat.number} key={stat.stadium} />
+            ))}
+        </StadiumStatSectionContainer>
+    )
+}
+
+export default StadiumStatSection

--- a/components/organisms/StadiumStatSection/index.ts
+++ b/components/organisms/StadiumStatSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StadiumStatSection'

--- a/const/data.ts
+++ b/const/data.ts
@@ -6,7 +6,7 @@ export const TEAM_STATS = [
 ]
 
 export const STADIUM_STATS = [
-    { stadium:'Estádio do Sport Lisboa e Benfica', location: 'Lisboa, Portugal', number: 1 },
+    { stadium:'Estádio do Sport Lisboa e Benfica', location: 'Lisboa, Portugal 🇵🇹', number: 1 },
     { stadium:'Estádio Municipal José Bento Pessoa', location: 'Figueira da Foz, Portugal', number: 1 },
     { stadium:'Estádio do Clube Desportivo das Aves', location: 'Vila das Aves - Santo Tirso, Portugal', number: 135 },
     { stadium:'Parque Desportivo Comendador Joaquim Almeida Freitas', location: 'Moreira de Cónegos -Guimarães, Portugal', number: 1 },

--- a/const/data.ts
+++ b/const/data.ts
@@ -1,0 +1,18 @@
+export const TEAM_STATS = [
+    { team:'Bor. Mönchengladbach', number: 12 },
+    { team:'Bayern Munich', number: 167 },
+    { team:'Tottenham Hotspur', number: 9 },
+    { team:'Deportivo La Coruna', number: 1 }
+]
+
+export const STADIUM_STATS = [
+    { stadium:'Estádio do Sport Lisboa e Benfica', location: 'Lisboa, Portugal', number: 1 },
+    { stadium:'Estádio Municipal José Bento Pessoa', location: 'Figueira da Foz, Portugal', number: 1 },
+    { stadium:'Estádio do Clube Desportivo das Aves', location: 'Vila das Aves - Santo Tirso, Portugal', number: 135 },
+    { stadium:'Parque Desportivo Comendador Joaquim Almeida Freitas', location: 'Moreira de Cónegos -Guimarães, Portugal', number: 1 },
+    { stadium:'Borussia PARK', location: 'Mönchengladbach, Germany', number: 1 },
+    { stadium:'Wanda Metropolitano', location: 'Madrid, Spain', number: 127 },
+    { stadium:'Allianz Arena', location: 'Munich, Germany 🇩🇪', number: 1101 },
+    { stadium:'Parc des Princes', location: 'Paris, France', number: 1 },
+    { stadium:'Stamford Bridge', location: 'London, England', number: 12 },
+]


### PR DESCRIPTION
Created `StadiumStatCard` and `StadiumStatSection` and adapted `AllStatsSection` to display the stadium stats cards in the "All Stats" section.
Also, created `data.ts` to have the sample data for the AllStatsSection props.


![Screenshot 2024-02-04 at 10 28 09](https://github.com/CarlosRafael22/jogoclub/assets/5307335/46cf209d-32a0-469c-bbb6-4a62d214c10c)

resolves #5 