### PR TITLE
[JC-24] Create MatchScore component

### DIFF
--- a/components/molecules/MatchScore/MatchScore.stories.tsx
+++ b/components/molecules/MatchScore/MatchScore.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryObj } from 'storybook'
+
+import MatchScore from './index'
+
+import { mockedMatchScoreWithKickoff, mockedMatchScoreInfo } from '@/mocks/match'
+
+const meta = {
+    title: 'Molecules/MatchScore',
+    component: MatchScore,
+    tags: ['autodocs']
+} satisfies Meta<typeof MatchScore>
+
+export default meta
+
+type Story = StoryObj<typeof MatchScore>
+
+const Template = (args) => (
+    <div className='w-80'>
+        <MatchScore {...args} />
+    </div>
+);
+
+export const Primary: Story = Template.bind({});
+Primary.args = mockedMatchScoreWithKickoff;
+
+export const WithScore: Story = Template.bind({});
+WithScore.args = mockedMatchScoreInfo;

--- a/components/molecules/MatchScore/index.tsx
+++ b/components/molecules/MatchScore/index.tsx
@@ -1,0 +1,36 @@
+import TeamNameBadge from "../TeamNameBadge";
+import { type TeamScoreInfo } from "entities/models/team";
+import { type ScoreInfo } from "entities/models/match";
+import Typography from "@/atoms/Typography";
+import { getFormattedDateAndHourFromDateString, getHourText } from "helpers";
+
+type Props = {
+    homeTeam: TeamScoreInfo;
+    awayTeam: TeamScoreInfo;
+    kickoff: string;
+    scoreInfo: ScoreInfo;
+}
+
+const MatchScore = ({ homeTeam, awayTeam, kickoff, scoreInfo }: Props) => {
+    const { name: homeTeamName, code: homeTeamCode, logoUrl: homeTeamLogoUrl } = homeTeam;
+    const { name: awayTeamName, code: awayTeamCode, logoUrl: awayTeamLogoUrl } = awayTeam;
+
+    const [formattedDate, formattedHour] = getFormattedDateAndHourFromDateString(kickoff);
+    const boxText = scoreInfo ? `${scoreInfo.homeTeamScore} - ${scoreInfo.awayTeamScore}` : formattedHour;
+    const dateTimeInfo = scoreInfo ? `${formattedDate} - ${getHourText(formattedHour)}` : formattedDate;
+    
+    return (
+        <div className="flex flex-col gap-1 items-center">
+            <div className="flex flex-row gap-1 items-center">
+                <TeamNameBadge name={homeTeamName} code={homeTeamCode} logoUrl={homeTeamLogoUrl} isHomeTeam={true} />
+                <div className="bg-gray-300 px-2 py-1 rounded flex items-center h-fit mx-1">
+                    <Typography variant="body1-bold">{boxText}</Typography>
+                </div>
+                <TeamNameBadge name={awayTeamName} code={awayTeamCode} logoUrl={awayTeamLogoUrl} />
+            </div>
+            <Typography variant="body2-bold">{dateTimeInfo}</Typography>
+        </div>
+    );
+};
+
+export default MatchScore;

--- a/components/molecules/TeamNameBadge/TeamNameBadge.stories.tsx
+++ b/components/molecules/TeamNameBadge/TeamNameBadge.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from 'storybook'
+
+import TeamNameBadge from './index'
+import { mockedHomeAndAwayTeam } from '@/mocks/match'
+
+const meta = {
+    title: 'Molecules/TeamNameBadge',
+    component: TeamNameBadge,
+    tags: ['autodocs'],
+    argTypes: {
+        isHomeTeam: {
+          control: 'select',
+          options: [true, false],
+          defaultValue: true
+        },
+      },
+} satisfies Meta<typeof TeamNameBadge>
+
+export default meta
+
+type Story = StoryObj<typeof TeamNameBadge>
+
+const Template = (args) => (
+    <div className='bg-sky-300 w-fit'>
+        <TeamNameBadge {...args} />
+    </div>
+);
+
+export const Primary: Story = Template.bind({});
+Primary.args = {
+    ...mockedHomeAndAwayTeam.homeTeam,
+    isHomeTeam: true
+};

--- a/components/molecules/TeamNameBadge/index.tsx
+++ b/components/molecules/TeamNameBadge/index.tsx
@@ -1,0 +1,29 @@
+import Typography from "@/atoms/Typography";
+
+type Props = {
+    name: string;
+    code: string;
+    logoUrl: string;
+    isHomeTeam?: boolean;
+}
+
+const TeamNameBadge = ({ name, code, logoUrl, isHomeTeam = false }: Props) => {
+    return (
+        <div className="flex flex-row h-12 w-24 items-center justify-between">
+            {
+            isHomeTeam ? (
+                <>
+                    <img src={logoUrl} alt={name} width={48} height={48} />
+                    <Typography variant='body1-bold'>{code}</Typography>
+                </>
+            ) : (
+                <>
+                    <Typography variant='body1-bold'>{code}</Typography>
+                    <img src={logoUrl} alt={name} width={48} height={48} />
+                </>
+            )}
+        </div>
+    );
+};
+
+export default TeamNameBadge;

--- a/entities/models/match.ts
+++ b/entities/models/match.ts
@@ -1,0 +1,4 @@
+export type ScoreInfo = {
+    homeTeamScore: number;
+    awayTeamScore: number;
+}

--- a/entities/models/team.ts
+++ b/entities/models/team.ts
@@ -1,0 +1,5 @@
+export type TeamScoreInfo = {
+    name: string;
+    code: string;
+    logoUrl: string;
+};

--- a/helpers/index.test.ts
+++ b/helpers/index.test.ts
@@ -1,4 +1,4 @@
-import { getCountryCode, getFlagEmoji } from "./index";
+import { getCountryCode, getFlagEmoji, getFormattedDateAndHourFromDateString, getHourText } from "./index";
 
 describe('getCountryCode', () => {
     const testCases = [
@@ -39,4 +39,24 @@ describe('getFlagEmoji', () => {
         const flag = getFlagEmoji(country)
         expect(flag).toBe(expectedFlag);
       });
-})
+});
+
+describe('getFormattedDateAndHourFromDateString', () => {
+    it('should get the right result', () => {
+        const text = getFormattedDateAndHourFromDateString("2024-02-26T19:00:00Z");
+        expect(text).toEqual(["Monday, 26 February 2024", "20:00"]);
+    });
+});
+
+describe('getHourText', () => {
+    const testCases = [
+        ['20:00', '20h'],
+        ['20:40', '20:40h'],
+        ['01:00', '01h']
+    ];
+
+    test.each(testCases)('should return the correct text for %s', (hour, expectedText) => {
+        const text = getHourText(hour);
+        expect(text).toBe(expectedText);
+    });
+});

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -23,4 +23,29 @@ export const getFlagEmoji = (countryCode: string | undefined): string | null => 
 }
 
 /** Returns the ISO Alpha-2 code for the country */
-export const getCountryCode = (country: string | undefined): string | undefined => COUNTRY_CODE_LIST.find(countryObj => countryObj.name === country)?.code
+export const getCountryCode = (country: string | undefined): string | undefined => COUNTRY_CODE_LIST.find(countryObj => countryObj.name === country)?.code;
+
+export const getFormattedDateAndHourFromDateString = (initialDateString: string): [formmattedDate: string, formmattedHour: string] => {
+    const dateObject = new Date(Date.parse(initialDateString));
+
+    const optionsDate = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    } as const;
+
+    const optionsHour = {
+        hour: 'numeric',
+        minute: "numeric",
+    } as const;
+
+    const formatterDate = new Intl.DateTimeFormat("en-GB", optionsDate);
+    const formattedDate = formatterDate.format(dateObject);
+
+    const formatterHour = new Intl.DateTimeFormat("en-GB", optionsHour);
+    const formattedHour = formatterHour.format(dateObject);
+    return [formattedDate, formattedHour];
+}
+
+export const getHourText = (hour: string) => hour.replace(':00', '').concat('h');

--- a/mocks/match.ts
+++ b/mocks/match.ts
@@ -1,4 +1,4 @@
-const homeAndAwayTeam = {
+export const mockedHomeAndAwayTeam = {
     homeTeam: {
         name: 'FC Bayern Munich',
         code: 'BAY',
@@ -12,13 +12,13 @@ const homeAndAwayTeam = {
 };
 
 export const mockedMatchScoreWithKickoff = {
-    ...homeAndAwayTeam,
+    ...mockedHomeAndAwayTeam,
     kickoff: "2024-02-26T19:00:00Z",
     scoreInfo: null
 }
 
 export const mockedMatchScoreInfo = {
-    ...homeAndAwayTeam,
+    ...mockedHomeAndAwayTeam,
     kickoff: "2024-02-26T19:00:00Z",
     scoreInfo: {
         homeTeamScore: 2,

--- a/mocks/match.ts
+++ b/mocks/match.ts
@@ -1,0 +1,27 @@
+const homeAndAwayTeam = {
+    homeTeam: {
+        name: 'FC Bayern Munich',
+        code: 'BAY',
+        logoUrl: 'https://i0.wp.com/worldsoccerpins.com/wp-content/uploads/2024/06/FC-Bayern-Munchen.png?resize=48%2C48&ssl=1'
+    },
+    awayTeam: {
+        name: 'Bayer Leverkusen',
+        code: 'LEV',
+        logoUrl: 'https://i0.wp.com/worldsoccerpins.com/wp-content/uploads/2024/06/Bayer-Leverkusen.png?h=48&ssl=1'
+    }
+};
+
+export const mockedMatchScoreWithKickoff = {
+    ...homeAndAwayTeam,
+    kickoff: "2024-02-26T19:00:00Z",
+    scoreInfo: null
+}
+
+export const mockedMatchScoreInfo = {
+    ...homeAndAwayTeam,
+    kickoff: "2024-02-26T19:00:00Z",
+    scoreInfo: {
+        homeTeamScore: 2,
+        awayTeamScore: 1
+    }
+}


### PR DESCRIPTION
AS a groundhopper
I WANT to see the logos, name code, time of the match and score
SO THAT I can see all the main information

Details:

For past matches, we see the score in the centre
For upcoming matches, we see the time in the centre

resolves #24 