### PR TITLE
[JC-17] Update new version of "Upcoming matches" section with new MatchCard component

### DIFF
--- a/components/molecules/MatchCard/MatchCard.stories.tsx
+++ b/components/molecules/MatchCard/MatchCard.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from 'storybook'
+
+import MatchCard from './index'
+
+import { mockedUpcomingMatch } from '@/mocks/match'
+
+const meta = {
+    title: 'Molecules/MatchCard',
+    component: MatchCard,
+    tags: ['autodocs'],
+    parameters: {
+        backgrounds: {
+            default: 'Gray',
+            values: [
+              { name: 'Gray', value: '#CCC' },
+            ],
+          },
+    },
+} satisfies Meta<typeof MatchCard>
+
+export default meta
+
+type Story = StoryObj<typeof MatchCard>
+
+const Template = (args) => (
+    <div className='w-80'>
+        <MatchCard {...args} />
+    </div>
+);
+
+export const Primary: Story = Template.bind({});
+Primary.args = mockedUpcomingMatch;

--- a/components/molecules/MatchCard/index.tsx
+++ b/components/molecules/MatchCard/index.tsx
@@ -1,0 +1,25 @@
+import MatchScore from "../MatchScore";
+import Typography from "@/atoms/Typography";
+import { type BasicMatchInfo } from "entities/models/match";
+
+const MatchCard = ({
+    homeTeam,
+    awayTeam,
+    kickoff,
+    scoreInfo,
+    competition,
+    stadium,
+}: BasicMatchInfo) => {
+
+    return (
+        <div className="flex flex-col rounded-lg bg-white p-4 w-full max-w-96">
+            <div className="flex flex-row justify-between mb-4">
+                <Typography variant="body1-bold">{competition}</Typography>
+                <Typography variant="body1-bold">{stadium}</Typography>
+            </div>
+            <MatchScore homeTeam={homeTeam} awayTeam={awayTeam} kickoff={kickoff} scoreInfo={scoreInfo} />
+        </div>
+    );
+};
+
+export default MatchCard;

--- a/components/molecules/MatchScore/index.tsx
+++ b/components/molecules/MatchScore/index.tsx
@@ -1,15 +1,9 @@
 import TeamNameBadge from "../TeamNameBadge";
-import { type TeamScoreInfo } from "entities/models/team";
-import { type ScoreInfo } from "entities/models/match";
+import { type BasicMatchInfo } from "entities/models/match";
 import Typography from "@/atoms/Typography";
 import { getFormattedDateAndHourFromDateString, getHourText } from "helpers";
 
-type Props = {
-    homeTeam: TeamScoreInfo;
-    awayTeam: TeamScoreInfo;
-    kickoff: string;
-    scoreInfo: ScoreInfo;
-}
+type Props = Omit<BasicMatchInfo, "competition" | "stadium">;
 
 const MatchScore = ({ homeTeam, awayTeam, kickoff, scoreInfo }: Props) => {
     const { name: homeTeamName, code: homeTeamCode, logoUrl: homeTeamLogoUrl } = homeTeam;
@@ -20,7 +14,7 @@ const MatchScore = ({ homeTeam, awayTeam, kickoff, scoreInfo }: Props) => {
     const dateTimeInfo = scoreInfo ? `${formattedDate} - ${getHourText(formattedHour)}` : formattedDate;
     
     return (
-        <div className="flex flex-col gap-1 items-center">
+        <div className="flex flex-col gap-2 items-center">
             <div className="flex flex-row gap-1 items-center">
                 <TeamNameBadge name={homeTeamName} code={homeTeamCode} logoUrl={homeTeamLogoUrl} isHomeTeam={true} />
                 <div className="bg-gray-300 px-2 py-1 rounded flex items-center h-fit mx-1">
@@ -28,7 +22,7 @@ const MatchScore = ({ homeTeam, awayTeam, kickoff, scoreInfo }: Props) => {
                 </div>
                 <TeamNameBadge name={awayTeamName} code={awayTeamCode} logoUrl={awayTeamLogoUrl} />
             </div>
-            <Typography variant="body2-bold">{dateTimeInfo}</Typography>
+            <p className="text-sm font-bold">{dateTimeInfo}</p>
         </div>
     );
 };

--- a/components/organisms/UpcomingMatchesSection/UpcomingMatchesSection.stories.tsx
+++ b/components/organisms/UpcomingMatchesSection/UpcomingMatchesSection.stories.tsx
@@ -1,10 +1,19 @@
 import { Meta, StoryObj } from 'storybook'
 import UpcomingMatchesSection from './UpcomingMatchesSection'
 import { UPCOMING_MATCHES } from 'const/data'
+import { mockedUpcomingMatch } from '@/mocks/match'
 
 const meta = {
     title: 'Organisms/UpcomingMatchesSection',
-    component: UpcomingMatchesSection
+    component: UpcomingMatchesSection,
+    parameters: {
+        backgrounds: {
+            default: 'Gray',
+            values: [
+              { name: 'Gray', value: '#CCC' },
+            ],
+          },
+    },
 } satisfies Meta<typeof UpcomingMatchesSection>
 
 export default meta
@@ -13,7 +22,7 @@ type Story = StoryObj<typeof UpcomingMatchesSection>
 
 export const Primary: Story = {
     args: {
-        upcomingMatches: UPCOMING_MATCHES,
+        upcomingMatches: Array(4).fill(mockedUpcomingMatch),
         previousMatches: UPCOMING_MATCHES
     },
 }

--- a/components/organisms/UpcomingMatchesSection/UpcomingMatchesSection.tsx
+++ b/components/organisms/UpcomingMatchesSection/UpcomingMatchesSection.tsx
@@ -1,49 +1,33 @@
 import React from 'react'
-import styled from 'styled-components'
 
 import Typography from '@/atoms/Typography'
+import MatchCard from '@/molecules/MatchCard'
+import { type BasicMatchInfo } from 'entities/models/match'
 import THEME from 'styles/theme'
 import Match from '@/interfaces/match'
 
-const UpcomingMatchesSectionWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    width: 90%;
-    margin-top: 48px;
-`
-
-const UpcomingMatchesSectionContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding: 8px 0px;
-    border-top: 2px solid white;
-`
-
-const UpcomingMatchesList = styled.div`
-    margin-top: 16px;
-`
-
 interface Props {
-    upcomingMatches: Match[]
+    upcomingMatches: BasicMatchInfo[]
     previousMatches: Match[]
 }
 
 const UpcomingMatchesSection = ({ upcomingMatches, previousMatches }: Props) => {
     return (
-        <UpcomingMatchesSectionWrapper>
+        <div className='flex flex-col mt-12 w-[90%]'>
             <Typography variant='body1-bold' align='right' color={THEME.colors.primaryBlue}>{`All Matches (${previousMatches.length}) >`}</Typography>
-            <UpcomingMatchesSectionContainer>
+            <div className='flex flex-col gap-2 py-2 border-t-2 border-s-white'>
                 <Typography variant='subtitle2-bold' align='left'>Upcoming Matches</Typography>
-                <UpcomingMatchesList>
+                <div className='flex flex-col items-center mt-4 gap-4'>
                     {upcomingMatches.length > 0 ? (
-                        <div>Matches coming</div>
+                        upcomingMatches.map(match => (
+                            <MatchCard {...match} />
+                        ))
                     ) : (
                         <Typography variant='body1-bold'>No matches scheduled to go.</Typography>
                     )}
-                </UpcomingMatchesList>
-            </UpcomingMatchesSectionContainer>
-        </UpcomingMatchesSectionWrapper>
+                </div>
+            </div>
+        </div>
     )
 }
 

--- a/components/pages/GroundhopperPage.tsx
+++ b/components/pages/GroundhopperPage.tsx
@@ -3,6 +3,7 @@ import ProfileHeader from "@/molecules/ProfileHeader";
 import SocialMediaSection from "@/molecules/SocialMediaSection";
 import ProfilePageStatsSection from "@/organisms/ProfilePageStatsSection";
 import UpcomingMatchesSection from "@/organisms/UpcomingMatchesSection";
+import { mockedUpcomingMatch } from "@/mocks/match";
 import { DEVICES } from "styles/theme";
 
 const Container = styled.div`
@@ -34,7 +35,7 @@ const GroundhopperPage = () => {
             <ProfileHeader />
             <SocialMediaSection />
             <ProfilePageStatsSection />
-            <UpcomingMatchesSection upcomingMatches={matches} previousMatches={matches} />
+            <UpcomingMatchesSection upcomingMatches={Array(4).fill(mockedUpcomingMatch)} previousMatches={matches} />
         </Container>
     );
 }

--- a/entities/models/match.ts
+++ b/entities/models/match.ts
@@ -1,4 +1,15 @@
+import { BasicTeamIdentity } from "./team";
+
 export type ScoreInfo = {
     homeTeamScore: number;
     awayTeamScore: number;
+}
+
+export type BasicMatchInfo = {
+    homeTeam: BasicTeamIdentity;
+    awayTeam: BasicTeamIdentity;
+    kickoff: string;
+    scoreInfo?: ScoreInfo;
+    competition: string;
+    stadium: string;
 }

--- a/entities/models/team.ts
+++ b/entities/models/team.ts
@@ -1,4 +1,4 @@
-export type TeamScoreInfo = {
+export type BasicTeamIdentity = {
     name: string;
     code: string;
     logoUrl: string;

--- a/mocks/match.ts
+++ b/mocks/match.ts
@@ -15,7 +15,13 @@ export const mockedMatchScoreWithKickoff = {
     ...mockedHomeAndAwayTeam,
     kickoff: "2024-02-26T19:00:00Z",
     scoreInfo: null
-}
+};
+
+export const mockedUpcomingMatch = {
+    ...mockedMatchScoreWithKickoff,
+    competition: "Bundesliga",
+    stadium: "Allianz Arena"
+};
 
 export const mockedMatchScoreInfo = {
     ...mockedHomeAndAwayTeam,
@@ -24,4 +30,4 @@ export const mockedMatchScoreInfo = {
         homeTeamScore: 2,
         awayTeamScore: 1
     }
-}
+};


### PR DESCRIPTION
Creates `MatchCard` components and add examples to Upcoming matches section.


<img width="394" alt="Screenshot 2024-09-22 at 01 07 43" src="https://github.com/user-attachments/assets/75dace3f-2a64-4153-95db-29be2f0c416e">

resolves #17 