### PR TITLE
Fix hydration issue due to not matching date strings

### DIFF
--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -41,7 +41,9 @@ export const getFormattedDateAndHourFromDateString = (initialDateString: string)
     } as const;
 
     const formatterDate = new Intl.DateTimeFormat("en-GB", optionsDate);
-    const formattedDate = formatterDate.format(dateObject);
+    const formattedParts = formatterDate.formatToParts(dateObject);
+    const [weekday, month, day, year] = formattedParts.filter(({ type }) => type !== 'literal');
+    const formattedDate = `${weekday.value}, ${month.value} ${day.value} - ${year.value}`;
 
     const formatterHour = new Intl.DateTimeFormat("en-GB", optionsHour);
     const formattedHour = formatterHour.format(dateObject);


### PR DESCRIPTION
Due to mismatching strings generated by the `Intl.DateTimeFormat` format function in the NextJS server and the browser, the hydration issue was occurring.
<img width="1672" alt="Screenshot 2024-09-28 at 16 48 13" src="https://github.com/user-attachments/assets/d0d67be0-f6c2-460e-a039-31cd06af23fa">

Server generated string:
<img width="292" alt="Screenshot 2024-09-28 at 17 22 23" src="https://github.com/user-attachments/assets/2c144dc4-4769-459a-815e-2fc63b85761a">

Browser generated string:
<img width="568" alt="Screenshot 2024-09-28 at 17 22 51" src="https://github.com/user-attachments/assets/d8d4bfba-7bc0-44e4-8901-6d78ccea860c">


After some investigation, I fixed the issue generating the string for the date with `formatParts` instead of relying on the format function with produces different outcome between browser and server.